### PR TITLE
temporarily disable archive banner

### DIFF
--- a/app/views/projects/show.html.slim
+++ b/app/views/projects/show.html.slim
@@ -3,7 +3,7 @@
 = render 'projects/meta_tags'
 
 .project-page
-  = render 'projects/archive'
+  / = render 'projects/archive'
   = render 'projects/header'
   = render 'projects/status_bar'
 

--- a/app/views/projects/show.html.slim
+++ b/app/views/projects/show.html.slim
@@ -3,7 +3,8 @@
 = render 'projects/meta_tags'
 
 .project-page
-  / = render 'projects/archive'
+  - unless @project.online?
+    = render 'projects/archive'
   = render 'projects/header'
   = render 'projects/status_bar'
 


### PR DESCRIPTION
We have a third party using our code that has one final campaign outstanding, so we're disabling this for the next two weeks.